### PR TITLE
Parse object validation

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -22,6 +22,6 @@ type Handler struct {
 }
 
 type Request struct {
-	Validate map[string]string `json:"validate" yaml:"validate"`
-	Match    json.RawMessage   `json:"match" yaml:"match"`
+	Validate map[string]any  `json:"validate" yaml:"validate"`
+	Match    json.RawMessage `json:"match" yaml:"match"`
 }

--- a/internal/config/parse_test.go
+++ b/internal/config/parse_test.go
@@ -19,22 +19,23 @@ func TestParseJSON(t *testing.T) {
 		{
 			it: "it parse config",
 
-			config: []byte(`{
-				"prepareErrorPath": "/prepare-error",
-				"handlers": [
-				  {
-					"path": "/example-path",
-					"method": "POST",
-					"response": { "info": { "success": true }, "data": "post validate request success data" },
-					"request": {
-					  "validate": {
-						"example": "required,lowercase,min=5"
-					  },
-					  "match": { "example": "mock-request-body" }
-					}
-				  }
-				]
-			  }`),
+			config: []byte(`
+				{
+					"prepareErrorPath": "/prepare-error",
+					"handlers": [
+						{
+							"path": "/example-path",
+							"method": "POST",
+							"response": { "info": { "success": true }, "data": "post validate request success data" },
+							"request": {
+								"validate": {
+									"example": "required,lowercase,min=5"
+								},
+								"match": { "example": "mock-request-body" }
+							}
+						}
+					]
+				}`),
 
 			expectedResult: &config.Config{
 				PrepareErrorPath: "/prepare-error",
@@ -44,8 +45,50 @@ func TestParseJSON(t *testing.T) {
 						Method:   config.Post,
 						Response: []byte(`{ "info": { "success": true }, "data": "post validate request success data" }`),
 						Request: &config.Request{
-							Validate: map[string]string{
+							Validate: map[string]any{
 								"example": "required,lowercase,min=5",
+							},
+							Match: []byte(`{ "example": "mock-request-body" }`),
+						},
+					},
+				},
+			},
+		},
+		{
+			it: "it parse config",
+
+			config: []byte(`
+				{
+					"prepareErrorPath": "/prepare-error",
+					"handlers": [
+						{
+							"path": "/example-path",
+							"method": "POST",
+							"response": { "info": { "success": true }, "data": "post validate request success data" },
+							"request": {
+								"validate": {
+									"example": {
+										"mock": "value"
+									}
+								},
+								"match": { "example": "mock-request-body" }
+							}
+						}
+					]
+				}`),
+
+			expectedResult: &config.Config{
+				PrepareErrorPath: "/prepare-error",
+				Handlers: []config.Handler{
+					{
+						Path:     "/example-path",
+						Method:   config.Post,
+						Response: []byte(`{ "info": { "success": true }, "data": "post validate request success data" }`),
+						Request: &config.Request{
+							Validate: map[string]any{
+								"example": map[string]any{
+									"mock": "value",
+								},
 							},
 							Match: []byte(`{ "example": "mock-request-body" }`),
 						},

--- a/internal/validate/validate.go
+++ b/internal/validate/validate.go
@@ -2,6 +2,7 @@ package validate
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -34,14 +35,38 @@ func fieldsValidation(r *http.Request, req *config.Request) error {
 		return err
 	}
 
-	for k, v := range req.Validate {
-		if httpReq[k] == nil && !strings.Contains(v, "required") {
-			continue
-		}
+	err = validateObject(httpReq, req.Validate)
+	if err != nil {
+		return err
+	}
 
-		err = valid.Var(httpReq[k], v)
-		if err != nil {
-			return err
+	return nil
+}
+
+func validateObject(httpReq map[string]any, req map[string]any) error {
+	for k, v := range req {
+		switch v := v.(type) {
+		case string:
+			if httpReq[k] == nil && !strings.Contains(v, "required") {
+				break
+			}
+
+			err := valid.Var(httpReq[k], v)
+			if err != nil {
+				msg := err.Error()
+				msg = strings.Replace(msg, "Key: '' Error:Field validation for ''", fmt.Sprintf("Key: '%s' Error:Field validation for '%s'", k, k), 1)
+				return errors.New(msg)
+			}
+
+		case map[string]any:
+			h, ok := httpReq[k].(map[string]any)
+			if !ok {
+				return fmt.Errorf("object of Key: '%s' not present", k)
+			}
+			err := validateObject(h, v)
+			if err != nil {
+				return err
+			}
 		}
 	}
 


### PR DESCRIPTION
Previously it would not parse this correctly:
```
"validate": {
	"example": {
		"mock": "value"
	}
},
```

Now it supports nested objects.

Bonus: fixed error messages to name the proper `key` that failed validation.