### PR TITLE
Query param check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ bin/
 .idea/
 
 .env
+
+__debug*

--- a/README.md
+++ b/README.md
@@ -55,6 +55,15 @@ you can use ENV variable `CONFIG_PATH` so override it.
         "match": {
           "example": "mock-request-body"
         }
+      },
+      "responseEcho": {
+        "example.mock.mock-2.mock-3": "example.mock.mock-2.mock-3"
+      },
+      "queryParams": {
+        "test": {
+          "required": false,
+          "value": "test-value"
+        }
       }
     }
   ]
@@ -69,7 +78,12 @@ you can use ENV variable `CONFIG_PATH` so override it.
   - `request`:
     - `validate` key-value of properties that you want validated defined by [go-playground/validator](https://github.com/go-playground/validator) tags
     - `match` configures the mock to check for exact match with request
-  - `responseEcho` is a key-value set of dot notation properties you want to take from request and set in response. Example `some.property.you.want.in.response`
+  - `responseEcho` is a key-value set of dot notation properties you want to take from request and set in response.
+    - Simple example: `some.property.you.want.in.response`
+    - Array example: if `[2]` for example is present, it means take the 3rd element of array. Example `some.[2].property.you.[1].want.in.response`
+  - `queryParam` is a map of query params you want to check
+    - `required` if false it will not fail when not sent
+    - `value` value to compare to when it is sent. if not equal it will fail
 
 ### Port
 

--- a/example/mock-server.json
+++ b/example/mock-server.json
@@ -9,6 +9,19 @@
       }
     },
     {
+      "path": "/query",
+      "method": "GET",
+      "response": {
+        "msg": "Hello mock server!"
+      },
+      "queryParams": {
+        "test": {
+          "required": false,
+          "value": "test-value"
+        }
+      }
+    },
+    {
       "path": "/example-path",
       "method": "POST",
       "response": {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5,7 +5,7 @@ import (
 )
 
 const (
-	Path             = "/home/tmavrin/Documents/Repos/mock-http-server/example/mock-server.json"
+	Path             = "./example/mock-server.json"
 	ErrorHandlerPath = "/prepare-error"
 )
 
@@ -15,14 +15,20 @@ type Config struct {
 }
 
 type Handler struct {
-	Path         string            `json:"path" yaml:"path"`
-	Method       Method            `json:"method" yaml:"method"`
-	Response     json.RawMessage   `json:"response" yaml:"response"`
-	ResponseEcho map[string]string `json:"responseEcho" yaml:"responseEcho"`
-	Request      *Request          `json:"request" yaml:"request"`
+	Path         string                `json:"path" yaml:"path"`
+	Method       Method                `json:"method" yaml:"method"`
+	Response     json.RawMessage       `json:"response" yaml:"response"`
+	ResponseEcho map[string]string     `json:"responseEcho" yaml:"responseEcho"`
+	Request      *Request              `json:"request" yaml:"request"`
+	QueryParams  map[string]QueryParam `json:"queryParams" yaml:"queryParams"`
 }
 
 type Request struct {
 	Validate any             `json:"validate" yaml:"validate"`
 	Match    json.RawMessage `json:"match" yaml:"match"`
+}
+
+type QueryParam struct {
+	Required bool   `json:"required" yaml:"required"`
+	Value    string `json:"value" yaml:"value"`
 }

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -26,10 +26,17 @@ func Handler(h config.Handler) http.Handler {
 
 		var reqBody any
 
+		err := checkQueryParams(r, h.QueryParams)
+		if err != nil && !errors.Is(err, io.EOF) {
+			response.JSON(w, http.StatusBadRequest, err.Error())
+
+			return
+		}
+
 		if r.Body != nil {
 			err := json.NewDecoder(r.Body).Decode(&reqBody)
 			if err != nil && !errors.Is(err, io.EOF) {
-				response.JSON(w, http.StatusInternalServerError, err.Error())
+				response.JSON(w, http.StatusBadRequest, err.Error())
 
 				return
 			}

--- a/internal/handler/handler_test.go
+++ b/internal/handler/handler_test.go
@@ -73,6 +73,60 @@ func TestHandler(t *testing.T) {
 		},
 
 		{
+			it: "validate query params",
+
+			config: config.Handler{
+				Method:   http.MethodGet,
+				Path:     "/get?test=mock-value",
+				Response: []byte(`{"info":{"success":true},"data":"get request success data"}`),
+				QueryParams: map[string]config.QueryParam{
+					"test": {
+						Required: true,
+						Value:    "mock-value",
+					},
+				},
+			},
+
+			expectedStatus: http.StatusOK,
+			expectedResult: `{"info":{"success":true},"data":"get request success data"}`,
+		},
+		{
+			it: "validate non required query params",
+
+			config: config.Handler{
+				Method:   http.MethodGet,
+				Path:     "/get",
+				Response: []byte(`{"info":{"success":true},"data":"get request success data"}`),
+				QueryParams: map[string]config.QueryParam{
+					"test": {
+						Required: false,
+						Value:    "mock-value",
+					},
+				},
+			},
+
+			expectedStatus: http.StatusOK,
+			expectedResult: `{"info":{"success":true},"data":"get request success data"}`,
+		},
+		{
+			it: "validate bad query params",
+
+			config: config.Handler{
+				Method:   http.MethodGet,
+				Path:     "/get?test=invalid-value",
+				Response: []byte(`{"info":{"success":true},"data":"get request success data"}`),
+				QueryParams: map[string]config.QueryParam{
+					"test": {
+						Required: true,
+						Value:    "mock-value",
+					},
+				},
+			},
+
+			expectedStatus: http.StatusBadRequest,
+			expectedResult: `"query param test value 'invalid-value' does not match 'mock-value'"`,
+		},
+		{
 			it: "pass null as value on echo request without sent request property",
 
 			request: map[string]any{

--- a/internal/handler/query_param.go
+++ b/internal/handler/query_param.go
@@ -1,0 +1,22 @@
+package handler
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/tmavrin/mock-http-server/internal/config"
+)
+
+func checkQueryParams(r *http.Request, config map[string]config.QueryParam) error {
+	for key, c := range config {
+		if c.Required && !r.URL.Query().Has(key) {
+			return fmt.Errorf("required query param %s is not present", key)
+		} else if !c.Required && r.URL.Query().Get(key) == "" {
+			return nil
+		} else if c.Value != "" && r.URL.Query().Get(key) != c.Value {
+			return fmt.Errorf("query param %s value '%s' does not match '%s'", key, r.URL.Query().Get(key), c.Value)
+		}
+	}
+
+	return nil
+}

--- a/internal/handler/query_param.go
+++ b/internal/handler/query_param.go
@@ -11,9 +11,13 @@ func checkQueryParams(r *http.Request, config map[string]config.QueryParam) erro
 	for key, c := range config {
 		if c.Required && !r.URL.Query().Has(key) {
 			return fmt.Errorf("required query param %s is not present", key)
-		} else if !c.Required && r.URL.Query().Get(key) == "" {
+		}
+
+		if !c.Required && r.URL.Query().Get(key) == "" {
 			return nil
-		} else if c.Value != "" && r.URL.Query().Get(key) != c.Value {
+		}
+
+		if c.Value != "" && r.URL.Query().Get(key) != c.Value {
 			return fmt.Errorf("query param %s value '%s' does not match '%s'", key, r.URL.Query().Get(key), c.Value)
 		}
 	}


### PR DESCRIPTION
Added a check configured like:

```json
{
  "prepareErrorPath": "/prepare-error",
  "handlers": [
    {
      ...
      "queryParams": {
        "test": {
          "required": false,
          "value": "test-value"
        }
      }
    },
  ]
}
```

Where key in `queryParams` object is key to check in query params.
`required` boolean is if if the query is always required
`value` is value to compare to if required is true or not required but sent